### PR TITLE
Add GraphQL post resolver tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r server/requirements.txt pytest
+      - name: Run tests
+        run: pytest server/tests

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+from datetime import datetime
+import pytz
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(BASE_DIR)
+
+os.environ["DATABASE_URI"] = "sqlite:///:memory:"
+os.chdir(BASE_DIR)
+
+from api import db
+import app as app_module
+
+app = app_module.app
+
+
+@pytest.fixture
+def client():
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def add_post():
+    def _add(title="title", body="body"):
+        from api.models import Posts
+        post = Posts(title=title, body=body, created_at=datetime.now(pytz.timezone("America/Los_Angeles")))
+        db.session.add(post)
+        db.session.commit()
+        return post
+    return _add

--- a/server/tests/test_mutations.py
+++ b/server/tests/test_mutations.py
@@ -1,0 +1,58 @@
+
+def test_create_post(client):
+    mutation = """
+      mutation($title: String!, $body: String!){
+        createPost(title: $title, body: $body){
+          success
+          post { id title body }
+        }
+      }
+    """
+    response = client.post("/graphql", json={"query": mutation, "variables": {"title": "New", "body": "Entry"}})
+    assert response.status_code == 200
+    payload = response.get_json()["data"]["createPost"]
+    assert payload["success"] is True
+    assert payload["post"]["title"] == "New"
+
+
+def test_update_post(client, add_post):
+    post = add_post("Old", "Body")
+    mutation = """
+      mutation($id: ID!, $title: String, $body: String){
+        updatePost(id: $id, title: $title, body: $body){
+          success
+          post { id title body }
+        }
+      }
+    """
+    variables = {"id": post.id, "title": "Updated", "body": "New body"}
+    response = client.post("/graphql", json={"query": mutation, "variables": variables})
+    assert response.status_code == 200
+    payload = response.get_json()["data"]["updatePost"]
+    assert payload["success"] is True
+    assert payload["post"]["title"] == "Updated"
+
+
+def test_delete_post(client, add_post):
+    post = add_post("Title", "Body")
+    mutation = """
+      mutation($id: ID!){
+        deletePost(id: $id){
+          success
+          post { id }
+        }
+      }
+    """
+    response = client.post("/graphql", json={"query": mutation, "variables": {"id": post.id}})
+    assert response.status_code == 200
+    payload = response.get_json()["data"]["deletePost"]
+    assert payload["success"] is True
+    query = """
+      query($id: ID!){
+        getPost(id: $id){
+          success
+        }
+      }
+    """
+    verify = client.post("/graphql", json={"query": query, "variables": {"id": post.id}})
+    assert verify.get_json()["data"]["getPost"]["success"] is False

--- a/server/tests/test_queries.py
+++ b/server/tests/test_queries.py
@@ -1,0 +1,34 @@
+def test_list_posts(client, add_post):
+    add_post("First", "Body1")
+    add_post("Second", "Body2")
+    query = """
+        query {
+          listPosts(cursor: null, limit: 10) {
+            edges { node { id title body } }
+            pageInfo { hasNextPage hasPreviousPage }
+          }
+        }
+    """
+    response = client.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.get_json()["data"]["listPosts"]["edges"]
+    assert len(data) == 2
+    titles = [edge["node"]["title"] for edge in data]
+    assert titles == ["Second", "First"]
+
+
+def test_get_post(client, add_post):
+    post = add_post("Single", "Body")
+    query = """
+      query($id: ID!){
+        getPost(id: $id){
+          success
+          post { id title body }
+        }
+      }
+    """
+    response = client.post("/graphql", json={"query": query, "variables": {"id": post.id}})
+    assert response.status_code == 200
+    payload = response.get_json()["data"]["getPost"]
+    assert payload["success"] is True
+    assert payload["post"]["title"] == "Single"


### PR DESCRIPTION
## Summary
- add pytest suite for listPosts, getPost, and post mutations
- spin up Flask test client with in-memory SQLite for isolation
- run tests in GitHub Actions

## Testing
- `pytest server/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b6712fd8c4832484880e7bfe3496b8